### PR TITLE
make Parser a trait to allow inheritance

### DIFF
--- a/src/main/scala/io/gatling/jsonpath/Parser.scala
+++ b/src/main/scala/io/gatling/jsonpath/Parser.scala
@@ -46,7 +46,7 @@ object FastStringOps {
   }
 }
 
-object Parser extends RegexParsers {
+trait ParserBase extends RegexParsers {
 
   val NumberRegex = """-?\d+""".r
   val FieldRegex = """[$_\p{L}][$_\-\d\p{L}]*""".r
@@ -201,3 +201,5 @@ class Parser {
   val query = Parser.query
   def compile(jsonpath: String): Parser.ParseResult[List[PathToken]] = Parser.parse(query, jsonpath)
 }
+
+object Parser extends ParserBase


### PR DESCRIPTION
I'm currently using this lib to do some ops with JsonPaths and I would like to use the root parser inside another custom RegexParsers. Since Parser is an inner type, I can't do anything without extending your Parser.